### PR TITLE
Test changelog CI again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Added
 
+- Testing 123!
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and Freecam's versioning is based on [Semantic Versioning](https://semver.org/sp
 
 ### Added
 
-- Testing 123!
-
 ### Changed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Freecam
 [![Crowdin](https://badges.crowdin.net/freecam/localized.svg)](https://crowdin.com/project/freecam)
 
+<!-- No-op -->
+
 This mod allows you to control your camera separately from your player. While it is enabled, you can fly around and travel through blocks within your render distance. Disabling it will restore you to your original position. This can be useful for quickly inspecting builds and exploring your world. 
 
 This mod works in multiplayer, but may be considered cheating on some servers.


### PR DESCRIPTION
This time, a PR from `MinecraftFreecam` org repo → `MattSturgeon` user repo to try and reproduce the repo-boundary issue.

1. [No changelog and no existing comment](https://github.com/MattSturgeon/Freecam/actions/runs/23986774931) ✅ 
2. [This PR touches the changelog](https://github.com/MattSturgeon/Freecam/actions/runs/23986785888?pr=17) -> [Creating a new changelog comment](https://github.com/MattSturgeon/Freecam/actions/runs/23986899368) ✅ 
3. [Transitive error (modmenu maven)](https://github.com/MattSturgeon/Freecam/actions/runs/23986917731?pr=17) -> Workflow run unsuccessful and no changelog; leaving comment untouched ⏳   
4. Minimize changelog comment ❔ 
5. Un-minimize changelog comment ❔ 
